### PR TITLE
add LAYERDEPENDS on meta-linaro-toolchain

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,3 +8,6 @@ BBFILES += "${LAYERDIR}/common/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "renesas"
 BBFILE_PATTERN_renesas := "^${LAYERDIR}/"
 BBFILE_PRIORITY_renesas = "5"
+
+LAYERDEPENDS_renesas = "linaro-toolchain"
+


### PR DESCRIPTION
This change allows bitbake to alert users of missing layer dependencies. We also use LAYERDEPENDS to support machines in our Yocto web app.
